### PR TITLE
Upgrade to the latest `uuid` crate version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 libc = "0.2.40"
 
 [target."cfg(windows)".dependencies]
-uuid = "0.8.2"
+uuid = "1.0.0"
 winapi = { version = "0.3.4", features = ["winsock2", "processthreadsapi"] }
 
 [dev-dependencies]


### PR DESCRIPTION
The `uuid` has released a v1.0.0 crate with improvements and a commitment to stability for this version (see "Stability Commitment" in the [v1.0.0 release notes](https://github.com/uuid-rs/uuid/releases/tag/1.0.0)).