### PR TITLE
Bump uuid to 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 libc = "0.2.40"
 
 [target."cfg(windows)".dependencies]
-uuid = "0.8.2"
+uuid = "1.0.0"
 winapi = { version = "0.3.4", features = ["winsock2", "processthreadsapi"] }
 
 [dev-dependencies]


### PR DESCRIPTION
The uuid crate has finally reached 1.0, so I'm opening some PRs across the ecosystem to upgrade. Please consider cutting a minor release if possible, so dependent crates can remove uuid 0.8 from their tree :)