### PR TITLE
fix: do not erase systemd environment variables

### DIFF
--- a/src/unix.rs
+++ b/src/unix.rs
@@ -121,8 +121,6 @@ pub fn get_fds() -> Option<Vec<FdType>> {
             .and_then(|x| x.parse().ok())
             .unwrap_or(3);
 
-        env::remove_var("LISTEN_PID");
-        env::remove_var("LISTEN_FDS");
         if ok {
             return Some(
                 (0..count)


### PR DESCRIPTION
In some scenarios, one might need to call ListenFd::from_env many times. Due to those two problematic lines, this is impossible, as the first time will erase the environment, and all the others will be ListenFd::empty.

In case where one wants to call this from a library, or any such thing, it makes the library completely unusable. There is also no reason for it to mutate the environment like that. Keeping those variables has effectively no impact.