### PR TITLE
Set TCP listener to non-blocking mode on Tokio example

### DIFF
--- a/examples/axum-demo/src/main.rs
+++ b/examples/axum-demo/src/main.rs
@@ -13,7 +13,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // one (eg: no systemd or systemfd), open on port 3000 instead.
     let mut listenfd = listenfd::ListenFd::from_env();
     let listener = match listenfd.take_tcp_listener(0).unwrap() {
-        Some(listener) => TcpListener::from_std(listener),
+        Some(listener) => {
+            let _ = listener.set_nonblocking(true).unwrap();
+            TcpListener::from_std(listener)
+        },
         None => TcpListener::bind("0.0.0.0:3000").await,
     }?;
     axum::serve(listener, app).await?;


### PR DESCRIPTION
According to Tokio documentation, the socket must be in non_blocking mode when converted, otherwhise it will cause the thread to block.

https://github.com/tokio-rs/tokio/blob/88445e762c569b538ac3f8d3dbb76887db421207/tokio/src/net/tcp/listener.rs#L206-L209

Using the example code on the project it was not possible to have axum responding to requests.

This commit changes the example to help others setup listenfd on their projects.